### PR TITLE
Update spec file to enable builds again

### DIFF
--- a/amtc-web/Makefile
+++ b/amtc-web/Makefile
@@ -185,12 +185,12 @@ css/sb-admin-2.css:
 	rm -rf startbootstrap-sb-admin-2-3.3.7-1 sb.zip
 
 fonts/fontawesome-webfont.woff:
-	curl -Lso fa.zip http://fortawesome.github.io/Font-Awesome/assets/font-awesome-$(FONTAWESOME).zip
+	curl -Lso fa.zip https://github.com/FortAwesome/Font-Awesome/archive/v$(FONTAWESOME).zip
 	unzip -q fa.zip
-	mv font-awesome-$(FONTAWESOME)/css/font-awesome.min.css css
+	mv Font-Awesome-$(FONTAWESOME)/css/font-awesome.min.css css
 	mkdir -p fonts
-	mv font-awesome-$(FONTAWESOME)/fonts/* fonts
-	rm -rf fa.zip font-awesome-$(FONTAWESOME)
+	mv Font-Awesome-$(FONTAWESOME)/fonts/* fonts
+	rm -rf fa.zip Font-Awesome-$(FONTAWESOME)
 
 lib/Slim/Slim.php:
 	curl -Lso slim.zip https://github.com/slimphp/Slim/archive/2.x.zip

--- a/amtc.spec
+++ b/amtc.spec
@@ -4,7 +4,7 @@ Release:	1%{?dist}
 Summary:	Threaded remote power management commandline tool for intel vPro/AMT&DASH hosts
 
 Group:		Applications/System
-License:	CC BY 3.0
+License:	MIT
 URL:		https://github.com/schnoddelbotz/%{name}
 Source0:	https://github.com/schnoddelbotz/%{name}/archive/v%{version}.tar.gz
 

--- a/amtc.spec
+++ b/amtc.spec
@@ -8,8 +8,12 @@ License:	CC BY 3.0
 URL:		https://github.com/schnoddelbotz/%{name}
 Source0:	https://github.com/schnoddelbotz/%{name}/archive/v%{version}.tar.gz
 
-BuildRequires:  libcurl-devel,gnutls-devel
-Requires: libcurl,gnutls
+BuildRequires:	libcurl-devel
+BuildRequires:	gnutls-devel
+BuildRequires:	git
+BuildRequires:	vim-common
+Requires:	libcurl
+Requires:	gnutls
 
 ################################################################################
 # binary RPM: amtc

--- a/amtc.spec
+++ b/amtc.spec
@@ -1,13 +1,12 @@
 Name:		amtc
-Version:	#AMTCV#
+Version:	0.8.5
 Release:	1%{?dist}
 Summary:	Threaded remote power management commandline tool for intel vPro/AMT&DASH hosts
 
 Group:		Applications/System
 License:	CC BY 3.0
-URL:		https://github.com/schnoddelbotz/amtc
-Source0:	https://github.com/schnoddelbotz/amtc/archive/amtc-#AMTCV#.tar.gz
-BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+URL:		https://github.com/schnoddelbotz/%{name}
+Source0:	https://github.com/schnoddelbotz/%{name}/archive/v%{version}.tar.gz
 
 BuildRequires:  libcurl-devel,gnutls-devel
 Requires: libcurl,gnutls


### PR DESCRIPTION
Hello,

this patch is fixing the following things:
1. Version value is now hardcoded. This enables to use of plain source + spec file
2. Updated BuildRequires. Git and vim-common were needed in amtc build
3. Fontawesome link was broken and it is not working again. Replacing with working one
4. License in spec should match with project license

I tried to build it in COPR for now.
https://copr.fedorainfracloud.org/coprs/martstyk/amtc/build/941674/ 